### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tsingsound/go-cron
+module github.com/tsingson/cron
 
 go 1.12
 


### PR DESCRIPTION
While doing go get github.com/KaiserKarel/go-cron getting following error:

$go get github.com/KaiserKarel/go-cron
go: finding github.com/KaiserKarel/go-cron latest
go: github.com/KaiserKarel/go-cron@v0.0.0-20190801134603-57b7378d18ce: parsing go.mod: unexpected module path "github.com/tsingsound/go-cron"
go: error loading module requirements

Seems to me there is a typo in ~github.com/tsingsound/go-cron"....should it be "https://github.com/tsingson/cron"